### PR TITLE
fix:  Ensure that CloudWatch Log Group is encrypted with KMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - fix: CKV2_AWS_28 Ensure public facing ALB are protected by WAF
-- feat: more than one security group for ecs service 
+- feat: more than one security group for ecs service
 - feat: Add EC2 usage example
 - feat: Possibly use lb module for load-balancer resource
 - feat: Review ecs-service arguments, add and test those missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - fix: CKV_AWS_111 #Ensure IAM policies does not allow write access without constraints
 - fix: CKV_AWS_158 #Ensure that CloudWatch Log Group is encrypted by KMS
+- hotfix: deployment controller in minimum example
+- fix: egress rules for fargate example
 
 ## [1.1.4] - 2022-10-10
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - fix: CKV2_AWS_28 Ensure public facing ALB are protected by WAF
-- fix: CKV_AWS_111 #Ensure IAM policies does not allow write access without constraints
 - feat: Add EC2 usage example
 - feat: Possibly use lb module for load-balancer resource
 - feat: Review ecs-service arguments, add and test those missing.
@@ -18,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: use updated ecs cluster source for ecs cluster
 - feat: consolidate ecs cluster module and ecs service module into one
 
+## [1.1.4] - 2022-10-20
+### Changes
+- fix: CKV_AWS_111 #Ensure IAM policies does not allow write access without constraints
+- fix: CKV_AWS_158 #Ensure that CloudWatch Log Group is encrypted by KMS
 ## [1.1.4] - 2022-10-10
 ### Changes
 - fix: CKV_AWS_103: "Ensure that load balancer is using TLS 1.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - fix: CKV2_AWS_28 Ensure public facing ALB are protected by WAF
+- feat: more than one security group for ecs service 
 - feat: Add EC2 usage example
 - feat: Possibly use lb module for load-balancer resource
 - feat: Review ecs-service arguments, add and test those missing.
@@ -13,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add more options for module cloudwatch log group
 - feat: Exclusively use acm certificate (not self_signed_cert) for complete example
 - feat: use updated vpc source in examples
-- feat: add supporting resources for testing
 - feat: use updated ecs cluster source for ecs cluster
 - feat: consolidate ecs cluster module and ecs service module into one
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: use updated ecs cluster source for ecs cluster
 - feat: consolidate ecs cluster module and ecs service module into one
 
-## [1.1.4] - 2022-10-20
+## [1.1.5] - 2022-10-20
 ### Changes
 - fix: CKV_AWS_111 #Ensure IAM policies does not allow write access without constraints
 - fix: CKV_AWS_158 #Ensure that CloudWatch Log Group is encrypted by KMS
@@ -68,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: feature update.
 - feat: initial code commit
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-ecs-service/compare/1.1.4...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-ecs-service/compare/1.1.5...HEAD
+[1.1.4]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.5
 [1.1.4]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.4
 [1.1.3]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.3
 [1.1.2]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - fix: CKV_AWS_111 #Ensure IAM policies does not allow write access without constraints
 - fix: CKV_AWS_158 #Ensure that CloudWatch Log Group is encrypted by KMS
+
 ## [1.1.4] - 2022-10-10
 ### Changes
 - fix: CKV_AWS_103: "Ensure that load balancer is using TLS 1.2"
@@ -69,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: initial code commit
 
 [Unreleased]: https://github.com/boldlink/terraform-aws-ecs-service/compare/1.1.5...HEAD
-[1.1.4]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.5
+[1.1.5]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.5
 [1.1.4]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.4
 [1.1.3]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.3
 [1.1.2]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.2

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module "ecs_service" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ module "ecs_service" {
       cidr_blocks = ["0.0.0.0/0"]
     }
   ]
+  
+  service_security_group_egress = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 
   tags = {
     Name               = local.name

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ module "ecs_service" {
       cidr_blocks = ["0.0.0.0/0"]
     }
   ]
-  
+
   service_security_group_egress = [
     {
       from_port   = 0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module "ecs_service" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ module "ecs_service" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -15,36 +15,128 @@ Examples available [here](https://github.com/boldlink/terraform-aws-ecs-service/
 *NOTE*: These examples use the latest version of this module
 
 ```console
-module "cluster" {
-  source = "git::https://github.com/boldlink/terraform-aws-ecs-cluster.git?ref=1.0.1"
-  name   = local.name
-  configuration = {
-    execute_command_configuration = {
-      log_configuration = {
-        cloud_watch_encryption_enabled = true
-        cloud_watch_log_group_name     = aws_cloudwatch_log_group.cluster.name
-        s3_bucket_encryption_enabled   = false
-      }
-      logging = "OVERRIDE"
+data "aws_partition" "current" {}
+
+data "aws_ecs_cluster" "ecs" {
+  cluster_name = local.supporting_resources_name
+}
+
+data "aws_kms_alias" "supporting_kms" {
+  name = "alias/${local.supporting_resources_name}"
+}
+
+data "aws_vpc" "supporting" {
+  filter {
+    name   = "tag:Name"
+    values = [local.supporting_resources_name]
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "tag:Name"
+    values = ["${local.supporting_resources_name}*.pri.*"]
+  }
+}
+
+data "aws_subnet" "private" {
+  for_each = toset(data.aws_subnets.private.ids)
+  id       = each.value
+}
+
+data "aws_iam_policy_document" "ecs_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
 }
+```
 
-resource "aws_cloudwatch_log_group" "cluster" {
-  name              = "${local.name}-log-group"
-  retention_in_days = 0
-  tags = {
-    Name               = local.name
-    Environment        = "examples"
-    "user::CostCenter" = "terraform-registry"
-  }
+console```
+locals {
+  private_subnet_id = [
+    for i in data.aws_subnet.private : i.id
+  ]
+  name                      = "minimum-example"
+  cluster                   = data.aws_ecs_cluster.ecs.arn
+  supporting_resources_name = "terraform-aws-ecs-service"
+  vpc_id                    = data.aws_vpc.supporting.id
+  private_subnets           = local.private_subnet_id
+  partition                 = data.aws_partition.current.partition
+  default_container_definitions = jsonencode(
+    [
+      {
+        name      = local.name
+        image     = "boldlink/flaskapp"
+        cpu       = 10
+        memory    = 512
+        essential = true
+        portMappings = [
+          {
+            containerPort = 5000
+            hostPort      = 5000
+          }
+        ]
+      }
+    ]
+  )  
+  task_execution_role_policy_doc = jsonencode(
+    {
+      Version = "2012-10-17",
+      Statement = [{
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = ["arn:${local.partition}:logs:::log-group:${local.name}"]
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ]
+
+          Resource = ["*"]
+        }
+    ] }
+  )
 }
+```
 
+console```
 module "ecs_service" {
   source                     = "../../"
   name                       = local.name
-  cluster                    = module.cluster.id
-  deployment_controller_type = "EXTERNAL"
+  family                     = "${local.name}-task-definition"
+  network_mode               = "awsvpc"
+  cluster                    = local.cluster
+  vpc_id                     = local.vpc_id
+  task_role_policy           = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  task_execution_role        = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  task_execution_role_policy = local.task_execution_role_policy_doc
+  container_definitions      = local.default_container_definitions
+  kms_key_id                 = data.aws_kms_alias.supporting_kms.target_key_arn
+  network_configuration = {
+    subnets = local.private_subnets
+  }
+  service_security_group_ingress = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 
   tags = {
     Name               = local.name
@@ -73,7 +165,7 @@ module "ecs_service" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module "ecs_service" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 
 ## Modules
 
@@ -41,7 +41,7 @@
 | [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.task_execution_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_alias.supporting_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
 
 ## Modules
 

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -55,33 +55,6 @@ data "aws_iam_policy_document" "access_logs_bucket" {
 
 data "aws_elb_service_account" "main" {}
 
-data "aws_iam_policy_document" "task_execution_role_policy_doc" {
-  #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints"
-  statement {
-    effect = "Allow"
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = ["arn:${local.partition}:logs:::log-group:${local.name}"]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-
-    resources = ["*"]
-  }
-}
-
 data "aws_vpc" "supporting" {
   filter {
     name   = "tag:Name"
@@ -115,4 +88,8 @@ data "aws_subnet" "private" {
 
 data "aws_ecs_cluster" "ecs" {
   cluster_name = local.supporting_resources_name
+}
+
+data "aws_kms_alias" "supporting_kms" {
+  name = "alias/${local.supporting_resources_name}"
 }

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -36,6 +36,33 @@ locals {
     ]
   )
 
+  task_execution_role_policy_doc = jsonencode(
+    {
+      Version = "2012-10-17",
+      Statement = [{
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = ["arn:${local.partition}:logs:::log-group:${local.name}"]
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ]
+
+          Resource = ["*"]
+        }
+    ] }
+  )
+
   tags = {
     Name               = local.name
     Environment        = "examples"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,8 +9,7 @@ module "access_logs_bucket" {
 
 module "ecs_service_lb" {
   source = "../../"
-  #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints"
-  #checkov:skip=CKV_AWS_91:Ensure IAM policies does not allow write access without constraints"
+  #checkov:skip=CKV_AWS_91:"Ensure the ELBv2 (Application/Network) has access logging enabled"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   name                     = "${local.name}-service"
@@ -25,8 +24,9 @@ module "ecs_service_lb" {
   vpc_id                     = local.vpc_id
   task_role_policy           = data.aws_iam_policy_document.ecs_assume_role_policy.json
   task_execution_role        = data.aws_iam_policy_document.ecs_assume_role_policy.json
-  task_execution_role_policy = data.aws_iam_policy_document.task_execution_role_policy_doc.json
+  task_execution_role_policy = local.task_execution_role_policy_doc
   container_definitions      = local.default_container_definitions
+  kms_key_id                 = data.aws_kms_alias.supporting_kms.target_key_arn
   path                       = "/healthz"
   enable_deletion_protection = true
   load_balancer = {

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -34,7 +34,7 @@
 |------|------|
 | [aws_ecs_cluster.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
 | [aws_iam_policy_document.ecs_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.task_execution_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_alias.supporting_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
 
 ## Modules
 

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
 
 ## Modules
 

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/examples/fargate/data.tf
+++ b/examples/fargate/data.tf
@@ -11,33 +11,6 @@ data "aws_iam_policy_document" "ecs_assume_role_policy" {
   }
 }
 
-data "aws_iam_policy_document" "task_execution_role_policy_doc" {
-  #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints"
-  statement {
-    effect = "Allow"
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = ["arn:${local.partition}:logs:::log-group:${local.name}"]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-
-    resources = ["*"]
-  }
-}
-
 data "aws_vpc" "supporting" {
   filter {
     name   = "tag:Name"
@@ -59,4 +32,8 @@ data "aws_subnet" "private" {
 
 data "aws_ecs_cluster" "ecs" {
   cluster_name = local.supporting_resources_name
+}
+
+data "aws_kms_alias" "supporting_kms" {
+  name = "alias/${local.supporting_resources_name}"
 }

--- a/examples/fargate/locals.tf
+++ b/examples/fargate/locals.tf
@@ -27,6 +27,33 @@ locals {
     ]
   )
 
+  task_execution_role_policy_doc = jsonencode(
+    {
+      Version = "2012-10-17",
+      Statement = [{
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = ["arn:${local.partition}:logs:::log-group:${local.name}"]
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ]
+
+          Resource = ["*"]
+        }
+    ] }
+  )
+
   tags = {
     Name               = local.name
     Environment        = "examples"

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -15,7 +15,6 @@ module "ecs_service" {
   task_execution_role        = data.aws_iam_policy_document.ecs_assume_role_policy.json
   task_execution_role_policy = local.task_execution_role_policy_doc
   container_definitions      = local.default_container_definitions
-  path                       = "/healthz"
   retention_in_days          = 1
   enable_autoscaling         = true
   scalable_dimension         = "ecs:service:DesiredCount"

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -1,6 +1,5 @@
 module "ecs_service" {
-  source = "../../"
-  #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints"
+  source                   = "../../"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   name                     = "${local.name}-service"
@@ -14,13 +13,14 @@ module "ecs_service" {
   vpc_id                     = local.vpc_id
   task_role_policy           = data.aws_iam_policy_document.ecs_assume_role_policy.json
   task_execution_role        = data.aws_iam_policy_document.ecs_assume_role_policy.json
-  task_execution_role_policy = data.aws_iam_policy_document.task_execution_role_policy_doc.json
+  task_execution_role_policy = local.task_execution_role_policy_doc
   container_definitions      = local.default_container_definitions
   path                       = "/healthz"
   retention_in_days          = 1
   enable_autoscaling         = true
   scalable_dimension         = "ecs:service:DesiredCount"
   service_namespace          = "ecs"
+  kms_key_id                 = data.aws_kms_alias.supporting_kms.target_key_arn
   service_security_group_ingress = [
     {
       from_port   = 80

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -28,6 +28,14 @@ module "ecs_service" {
       cidr_blocks = ["0.0.0.0/0"]
     }
   ]
+  service_security_group_egress = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 
   tags = local.tags
 }

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
 
 ## Modules
 

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 
 ## Modules
 
@@ -33,7 +33,12 @@
 | Name | Type |
 |------|------|
 | [aws_ecs_cluster.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
+| [aws_iam_policy_document.ecs_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_alias.supporting_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.supporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 
 ## Modules
 
@@ -33,6 +33,7 @@
 | Name | Type |
 |------|------|
 | [aws_ecs_cluster.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
+| [aws_kms_alias.supporting_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 
 ## Inputs
 

--- a/examples/minimum/data.tf
+++ b/examples/minimum/data.tf
@@ -1,7 +1,39 @@
+data "aws_partition" "current" {}
+
 data "aws_ecs_cluster" "ecs" {
   cluster_name = local.supporting_resources_name
 }
 
 data "aws_kms_alias" "supporting_kms" {
   name = "alias/${local.supporting_resources_name}"
+}
+
+data "aws_vpc" "supporting" {
+  filter {
+    name   = "tag:Name"
+    values = [local.supporting_resources_name]
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "tag:Name"
+    values = ["${local.supporting_resources_name}*.pri.*"]
+  }
+}
+
+data "aws_subnet" "private" {
+  for_each = toset(data.aws_subnets.private.ids)
+  id       = each.value
+}
+
+data "aws_iam_policy_document" "ecs_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
 }

--- a/examples/minimum/data.tf
+++ b/examples/minimum/data.tf
@@ -1,3 +1,7 @@
 data "aws_ecs_cluster" "ecs" {
   cluster_name = local.supporting_resources_name
 }
+
+data "aws_kms_alias" "supporting_kms" {
+  name = "alias/${local.supporting_resources_name}"
+}

--- a/examples/minimum/locals.tf
+++ b/examples/minimum/locals.tf
@@ -1,5 +1,54 @@
 locals {
+  private_subnet_id = [
+    for i in data.aws_subnet.private : i.id
+  ]
   name                      = "minimum-example"
   cluster                   = data.aws_ecs_cluster.ecs.arn
   supporting_resources_name = "terraform-aws-ecs-service"
+  vpc_id                    = data.aws_vpc.supporting.id
+  private_subnets           = local.private_subnet_id
+  partition                 = data.aws_partition.current.partition
+  default_container_definitions = jsonencode(
+    [
+      {
+        name      = local.name
+        image     = "boldlink/flaskapp"
+        cpu       = 10
+        memory    = 512
+        essential = true
+        portMappings = [
+          {
+            containerPort = 5000
+            hostPort      = 5000
+          }
+        ]
+      }
+    ]
+  )
+  task_execution_role_policy_doc = jsonencode(
+    {
+      Version = "2012-10-17",
+      Statement = [{
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = ["arn:${local.partition}:logs:::log-group:${local.name}"]
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ]
+
+          Resource = ["*"]
+        }
+    ] }
+  )
 }

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -1,10 +1,26 @@
 module "ecs_service" {
   source                     = "../../"
   name                       = local.name
+  family                     = "${local.name}-task-definition"
+  network_mode               = "awsvpc"
   cluster                    = local.cluster
-  launch_type                = "EC2"
-  deployment_controller_type = "EXTERNAL"
+  vpc_id                     = local.vpc_id
+  task_role_policy           = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  task_execution_role        = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  task_execution_role_policy = local.task_execution_role_policy_doc
+  container_definitions      = local.default_container_definitions
   kms_key_id                 = data.aws_kms_alias.supporting_kms.target_key_arn
+  network_configuration = {
+    subnets = local.private_subnets
+  }
+  service_security_group_ingress = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 
   tags = {
     Name               = local.name

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -22,6 +22,15 @@ module "ecs_service" {
     }
   ]
 
+  service_security_group_egress = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
+
   tags = {
     Name               = local.name
     Environment        = "examples"

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -4,6 +4,7 @@ module "ecs_service" {
   cluster                    = local.cluster
   launch_type                = "EC2"
   deployment_controller_type = "EXTERNAL"
+  kms_key_id                 = data.aws_kms_alias.supporting_kms.target_key_arn
 
   tags = {
     Name               = local.name

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -32,9 +32,9 @@ This stack builds:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cluster"></a> [cluster](#module\_cluster) | git::https://github.com/boldlink/terraform-aws-ecs-cluster.git | 1.0.1 |
+| <a name="module_cluster"></a> [cluster](#module\_cluster) | boldlink/ecs-cluster/aws | 1.0.1 |
 | <a name="module_ecs_vpc"></a> [ecs\_vpc](#module\_ecs\_vpc) | boldlink/vpc/aws | 2.0.3 |
-| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | boldlink/kms/aws | n/a |
+| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | boldlink/kms/aws | 1.1.0 |
 
 ## Resources
 
@@ -43,6 +43,7 @@ This stack builds:
 | [aws_cloudwatch_log_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -26,7 +26,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -26,7 +26,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
 
 ## Modules
 

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -26,7 +26,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
 
 ## Modules
 

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -26,7 +26,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.36.0 |
 
 ## Modules
 

--- a/tests/supportingResources/data.tf
+++ b/tests/supportingResources/data.tf
@@ -1,7 +1,6 @@
 data "aws_availability_zones" "available" {
   state = "available"
 }
-
+data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
-
 data "aws_region" "current" {}

--- a/tests/supportingResources/locals.tf
+++ b/tests/supportingResources/locals.tf
@@ -2,10 +2,45 @@ locals {
   public_subnets  = [cidrsubnet(local.cidr_block, 8, 1), cidrsubnet(local.cidr_block, 8, 2), cidrsubnet(local.cidr_block, 8, 3)]
   private_subnets = [cidrsubnet(local.cidr_block, 8, 4), cidrsubnet(local.cidr_block, 8, 5), cidrsubnet(local.cidr_block, 8, 6)]
   region          = data.aws_region.current.id
+  dns_suffix      = data.aws_partition.current.dns_suffix
   account_id      = data.aws_caller_identity.current.id
+  partition       = data.aws_partition.current.partition
   azs             = flatten(data.aws_availability_zones.available.names)
   cidr_block      = "10.1.0.0/16"
   name            = "terraform-aws-ecs-service"
+
+  kms_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Allow KMS Permissions to cluster",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "logs.${local.region}.${local.dns_suffix}"
+        },
+        "Action" : [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ],
+        "Resource" : "*"
+      },
+
+      {
+        "Sid" : "Enable IAM User Permissions",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "arn:${local.partition}:iam::${local.account_id}:root"
+        },
+        "Action" : [
+          "kms:*"
+        ],
+        "Resource" : "*",
+      }
+    ]
+  })
   tags = {
     Environment        = "examples"
     "user::CostCenter" = "terraform-registry"

--- a/tests/supportingResources/main.tf
+++ b/tests/supportingResources/main.tf
@@ -17,24 +17,28 @@ module "ecs_vpc" {
 
 module "kms_key" {
   source                  = "boldlink/kms/aws"
+  version                 = "1.1.0"
   description             = "A test kms key for ecs cluster"
   create_kms_alias        = true
   alias_name              = "alias/${local.name}"
   enable_key_rotation     = true
+  kms_policy              = local.kms_policy
   deletion_window_in_days = 7
   tags                    = local.tags
 }
 
 resource "aws_cloudwatch_log_group" "cluster" {
-  #checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS"
-  name              = "${local.name}-log-group"
-  retention_in_days = 0
+  name              = "/aws/ecs-cluster/${local.name}-log-group"
+  retention_in_days = 1
+  kms_key_id        = module.kms_key.arn
   tags              = local.tags
 }
 
+
 module "cluster" {
-  source = "git::https://github.com/boldlink/terraform-aws-ecs-cluster.git?ref=1.0.1"
-  name   = local.name
+  source  = "boldlink/ecs-cluster/aws"
+  version = "1.0.1"
+  name    = local.name
   configuration = {
     execute_command_configuration = {
       kms_key_id = module.kms_key.key_id


### PR DESCRIPTION
# Description
This PR aims tofix checkov alerts in ecs-service module. The alerts are CKV_AWS_111 & CKV_AWS_158

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-ecs-service/blob/fix/CKV_AWS_158/CHANGELOG.md#114---2022-10-20)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [x] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
