### PR TITLE
feature: Added force_new_deployment attribute to ecs service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CKV2_AWS_5 Ensure that Security Groups are attached to another
 - CKV_AWS_150 Ensure that Load Balancer has deletion protection enabled
 
+
+## [1.4.0] - 2023-05-17
+### Changes
+- force_new_deployment attribute added to ecs service resource with default value `false`
+
 ## [1.3.0] - 2023-05-17
 ### Changes
 - enable_execute_command attribute added to the ecs service resource with default value `false`
@@ -94,8 +99,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: feature update.
 - feat: initial code commit
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-ecs-service/compare/1.1.7...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-ecs-service/compare/1.4.0...HEAD
 
+[1.4.0]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.4.0
+[1.3.0]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.3.0
+[1.2.0]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.2.0
 [1.1.7]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.7
 [1.1.6]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.6
 [1.1.5]: https://github.com/boldlink/terraform-aws-ecs-service/releases/tag/1.1.5

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ No modules.
 | <a name="input_enable_execute_command"></a> [enable\_execute\_command](#input\_enable\_execute\_command) | value to enable execute command at the ecs service, default = false | `bool` | `false` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Choose whether to enable key rotation | `bool` | `true` | no |
 | <a name="input_family"></a> [family](#input\_family) | (Required) A unique name for your task definition. | `string` | `null` | no |
+| <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g., myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered\_placement\_strategy and placement\_constraints updates. | `bool` | `false` | no |
 | <a name="input_healthy_threshold"></a> [healthy\_threshold](#input\_healthy\_threshold) | (Optional) Number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | `number` | `3` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | (Optional) If true, the LB will be internal. | `bool` | `false` | no |
 | <a name="input_key_deletion_window_in_days"></a> [key\_deletion\_window\_in\_days](#input\_key\_deletion\_window\_in\_days) | The number of days before the key is deleted | `number` | `7` | no |

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ resource "aws_ecs_service" "service" {
   deployment_maximum_percent         = var.tasks_maximum_percent
   launch_type                        = var.launch_type
   enable_execute_command             = var.enable_execute_command
+  force_new_deployment               = var.force_new_deployment
 
   deployment_controller {
     type = var.deployment_controller_type

--- a/variables.tf
+++ b/variables.tf
@@ -400,3 +400,9 @@ variable "enable_execute_command" {
   type        = bool
   default     = false
 }
+
+variable "force_new_deployment" {
+  description = "Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g., myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered_placement_strategy and placement_constraints updates."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# Description

This PR adds force_new_deployment attribute to ecs service resource.

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-ecs-service/blob/feature/force-new-deployment/CHANGELOG.md#140---2023-05-17)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [ ] Have you updated the `CHANGELOG.md`?
* [ ] Have you updated the `README.md`(s)?
* [ ] OWNER: Does your submission pass?
    * [ ] Pre-commit (attach logs/print screen to this PR)
    * [ ] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
